### PR TITLE
feat: allow version prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Otherwise the version and its breakdown are avaialbe through the outputs.
     echo "v${{ steps.semver.outputs.major }}"
     echo "v${{ steps.semver.outputs.minor }}"
     echo "v${{ steps.semver.outputs.patch }}"
+    echo "v${{ steps.semver.outputs.extra }}"
 ```
 
 ## Inputs
@@ -35,6 +36,7 @@ You can configure the action with the following parameters:
 
 > **Note** that a valid version can be with or without the `v` prefix.
 > This prefix will be stripped if present.
+> If you wish to keep the `v` prefix then you can manually add it when you use the outputs.
 
 ## Outputs
 
@@ -42,13 +44,15 @@ The following outputs are available through `steps.<id>.outputs` when the action
 
 | Name | Type | Description | Example |
 | ---- | --- | ------------ | ------- |
-| `version` | `string` | The full version wihout prefixes | `2.13.34` |
+| `version` | `string` | The full version wihout prefixes | `2.13.34-dev` |
 | `major` | `string` | The major version number | `2` |
 | `minor` | `string` | The minor version number | `13` |
 | `patch` | `string` | The patch version number | `34` |
+| `extra` | `string` | The prerelease version number | `dev` |
 
 > **Note** that because the version is coerced in to a semantic version all outputs will be present assuming the action succeeds.
 > That is, the version `v4` will mean that the outputs for `minor` and `patch` will be the string value `0`.
+> In all cases the `extra` output will always be an empty string (`""`) unless the version is a [prerelease version](https://semver.org/#spec-item-9).
 
 ## Resolution Strategy
 
@@ -67,3 +71,10 @@ If you instead supply a [git-ref](https://git-scm.com/book/en/v2/Git-Internals-G
 | `refs/tags/1` or `refs/tags/v1` | `1.0.0` |
 | `refs/tags/1.2` or `refs/tags/v1.2` | `1.2.0` |
 | `refs/tags/1.2.3` or `refs/tags/v1.2.3` | `1.2.3` |
+
+It is possible to also resolve [prerelease](https://semver.org/#spec-item-9) versions in the same way, this takes the first `-` and splits the version before trying to resolve.
+Should the version part resolve then the prerelease part is re-attached.
+
+| Input | Output |
+| ----- | ------ |
+| `v1-alpha.0` | `1.0.0-alpha.0` |

--- a/build/action.js
+++ b/build/action.js
@@ -241,10 +241,10 @@ var require_validate = __commonJS({
     function _interopRequireDefault(obj) {
       return obj && obj.__esModule ? obj : { default: obj };
     }
-    function validate2(uuid) {
+    function validate(uuid) {
       return typeof uuid === "string" && _regex.default.test(uuid);
     }
-    var _default = validate2;
+    var _default = validate;
     exports.default = _default;
   }
 });
@@ -1010,11 +1010,11 @@ var require_lib = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
+        return value instanceof P ? value : new P(function(resolve2) {
+          resolve2(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
+      return new (P || (P = Promise))(function(resolve2, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -1030,7 +1030,7 @@ var require_lib = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -1115,13 +1115,13 @@ var require_lib = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve2) => __awaiter(this, void 0, void 0, function* () {
             let output2 = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output2 = Buffer.concat([output2, chunk]);
             });
             this.message.on("end", () => {
-              resolve(output2.toString());
+              resolve2(output2.toString());
             });
           }));
         });
@@ -1313,14 +1313,14 @@ var require_lib = __commonJS({
       }
       requestRaw(info, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve, reject) => {
+          return new Promise((resolve2, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve(res);
+                resolve2(res);
               }
             }
             this.requestRawWithCallback(info, data, callbackForResult);
@@ -1465,12 +1465,12 @@ var require_lib = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve) => setTimeout(() => resolve(), ms));
+          return new Promise((resolve2) => setTimeout(() => resolve2(), ms));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve2, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -1478,7 +1478,7 @@ var require_lib = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve(response);
+              resolve2(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -1517,7 +1517,7 @@ var require_lib = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve(response);
+              resolve2(response);
             }
           }));
         });
@@ -1534,11 +1534,11 @@ var require_auth = __commonJS({
     "use strict";
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
+        return value instanceof P ? value : new P(function(resolve2) {
+          resolve2(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
+      return new (P || (P = Promise))(function(resolve2, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -1554,7 +1554,7 @@ var require_auth = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -1631,11 +1631,11 @@ var require_oidc_utils = __commonJS({
     "use strict";
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
+        return value instanceof P ? value : new P(function(resolve2) {
+          resolve2(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
+      return new (P || (P = Promise))(function(resolve2, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -1651,7 +1651,7 @@ var require_oidc_utils = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -1729,11 +1729,11 @@ var require_summary = __commonJS({
     "use strict";
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
+        return value instanceof P ? value : new P(function(resolve2) {
+          resolve2(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
+      return new (P || (P = Promise))(function(resolve2, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -1749,7 +1749,7 @@ var require_summary = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -1972,11 +1972,11 @@ var require_core = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
+        return value instanceof P ? value : new P(function(resolve2) {
+          resolve2(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
+      return new (P || (P = Promise))(function(resolve2, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -1992,7 +1992,7 @@ var require_core = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve2(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -2589,18 +2589,26 @@ var import_core = __toESM(require_core());
 
 // src/core/version.ts
 var import_coerce = __toESM(require_coerce());
-var validate = (value) => {
+var resolve = (value) => {
   const refless = value.replace(/^refs\/tags\//, "");
   const coerced = (0, import_coerce.default)(refless);
   if (coerced === null) {
-    return null;
+    return void 0;
+  }
+  let extra = "";
+  let version = coerced.format();
+  const prerelease = refless.indexOf("-");
+  if (prerelease > -1) {
+    extra = refless.slice(prerelease + 1);
+    version = `${version}-${extra}`;
   }
   return {
-    version: coerced.format(),
+    version,
     part: {
       major: coerced.major.toString(),
       minor: coerced.minor.toString(),
-      patch: coerced.patch.toString()
+      patch: coerced.patch.toString(),
+      extra
     }
   };
 };
@@ -2609,8 +2617,8 @@ var validate = (value) => {
 var action = async ({ input: input2, output: output2, fail: fail2 }) => {
   try {
     const version = input2("version", { required: true });
-    const validated = validate(version);
-    if (validated === null) {
+    const validated = resolve(version);
+    if (validated === void 0) {
       fail2("The value given is not a valid semantic version");
       return;
     }
@@ -2618,6 +2626,7 @@ var action = async ({ input: input2, output: output2, fail: fail2 }) => {
     output2("major", validated.part.major);
     output2("minor", validated.part.minor);
     output2("patch", validated.part.patch);
+    output2("extra", validated.part.extra);
   } catch (error) {
     fail2(`An unknown error occured: ${error}`);
   }

--- a/src/core/action.test.ts
+++ b/src/core/action.test.ts
@@ -19,12 +19,13 @@ describe('action()', (): void => {
 
     expect(input).toBeCalledTimes(1);
 
-    expect(output).toBeCalledTimes(4);
+    expect(output).toBeCalledTimes(5);
     expect(output.mock.calls).toEqual([
       ['version', '1.2.3'],
       ['major', '1'],
       ['minor', '2'],
       ['patch', '3'],
+      ['extra', ''],
     ]);
 
     expect(fail).toBeCalledTimes(0);
@@ -47,12 +48,42 @@ describe('action()', (): void => {
 
     expect(input).toBeCalledTimes(1);
 
-    expect(output).toBeCalledTimes(4);
+    expect(output).toBeCalledTimes(5);
     expect(output.mock.calls).toEqual([
       ['version', '10.23.4'],
       ['major', '10'],
       ['minor', '23'],
       ['patch', '4'],
+      ['extra', ''],
+    ]);
+
+    expect(fail).toBeCalledTimes(0);
+  });
+
+  it('with valid version input, suffixed with prerelease, outputs with prerelease', async (): Promise<void> => {
+    const input = fn<InputFunction>();
+    const output = fn<OutputFunction>();
+    const fail = fn<FailFunction>();
+
+    input.mockImplementationOnce(() => {
+      return '2.3-alpha.2';
+    });
+
+    await action({
+      input,
+      output,
+      fail,
+    });
+
+    expect(input).toBeCalledTimes(1);
+
+    expect(output).toBeCalledTimes(5);
+    expect(output.mock.calls).toEqual([
+      ['version', '2.3.0-alpha.2'],
+      ['major', '2'],
+      ['minor', '3'],
+      ['patch', '0'],
+      ['extra', 'alpha.2'],
     ]);
 
     expect(fail).toBeCalledTimes(0);
@@ -75,12 +106,42 @@ describe('action()', (): void => {
 
     expect(input).toBeCalledTimes(1);
 
-    expect(output).toBeCalledTimes(4);
+    expect(output).toBeCalledTimes(5);
     expect(output.mock.calls).toEqual([
       ['version', '4.36.14'],
       ['major', '4'],
       ['minor', '36'],
       ['patch', '14'],
+      ['extra', ''],
+    ]);
+
+    expect(fail).toBeCalledTimes(0);
+  });
+
+  it('with valid version input, git ref, tag, suffixed with prerelease, output version part with prerelease suffix', async (): Promise<void> => {
+    const input = fn<InputFunction>();
+    const output = fn<OutputFunction>();
+    const fail = fn<FailFunction>();
+
+    input.mockImplementationOnce(() => {
+      return 'refs/tags/v5.31.12-beta.1';
+    });
+
+    await action({
+      input,
+      output,
+      fail,
+    });
+
+    expect(input).toBeCalledTimes(1);
+
+    expect(output).toBeCalledTimes(5);
+    expect(output.mock.calls).toEqual([
+      ['version', '5.31.12-beta.1'],
+      ['major', '5'],
+      ['minor', '31'],
+      ['patch', '12'],
+      ['extra', 'beta.1'],
     ]);
 
     expect(fail).toBeCalledTimes(0);

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -1,5 +1,5 @@
 import type { InputOptions } from '@actions/core';
-import { validate } from './version';
+import { resolve } from './version';
 
 export type InputFunction = (name: string, options: InputOptions) => string;
 export type OutputFunction = (name: string, value: string) => void;
@@ -14,9 +14,9 @@ export type ActionDependencies = {
 export const action = async ({ input, output, fail }: ActionDependencies): Promise<void> => {
   try {
     const version = input('version', { required: true });
-    const validated = validate(version);
+    const validated = resolve(version);
 
-    if (validated === null) {
+    if (validated === undefined) {
       fail('The value given is not a valid semantic version');
 
       return;
@@ -26,6 +26,7 @@ export const action = async ({ input, output, fail }: ActionDependencies): Promi
     output('major', validated.part.major);
     output('minor', validated.part.minor);
     output('patch', validated.part.patch);
+    output('extra', validated.part.extra);
   } catch (error: unknown) {
     fail(`An unknown error occured: ${error}`);
   }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,4 +1,3 @@
-import type { Nullable } from '@matt-usurp/grok';
 import coerce from 'semver/functions/coerce';
 
 export type VersionBreakdown = {
@@ -8,24 +7,35 @@ export type VersionBreakdown = {
     readonly major: string;
     readonly minor: string;
     readonly patch: string;
+    readonly extra: string;
   };
 };
 
-export const validate = (value: string): Nullable<VersionBreakdown> => {
+export const resolve = (value: string): VersionBreakdown | undefined => {
   const refless = value.replace(/^refs\/tags\//, '');
   const coerced = coerce(refless);
 
   if (coerced === null) {
-    return null;
+    return undefined;
+  }
+
+  let extra = '';
+  let version = coerced.format();
+
+  const prerelease = refless.indexOf('-');
+  if (prerelease > -1) {
+    extra = refless.slice(prerelease + 1);
+    version = `${version}-${extra}`;
   }
 
   return {
-    version: coerced.format(),
+    version,
 
     part: {
       major: coerced.major.toString(),
       minor: coerced.minor.toString(),
       patch: coerced.patch.toString(),
+      extra,
     },
   };
 };


### PR DESCRIPTION
This introduces the ability to use `-prerelease` version format as mentioned [in the specification](https://semver.org/#spec-item-9). Now when a version is provided with a suffix denoted with a `-` it will attempt to re-attach the suffix once the version has been resolved. See the changed tests for further examples and use cases.