### PR TITLE
build: ensure github actions are using the correct node version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
 
       - run: node -v
       - run: npm -v


### PR DESCRIPTION
This was overlooked in the recent `v2` upgrade to `node@20`